### PR TITLE
Nuevo servicio para peticiones http componentes de contacto creado exitosamente

### DIFF
--- a/src/app/core/lib/utils.ts
+++ b/src/app/core/lib/utils.ts
@@ -1,0 +1,16 @@
+class Exception{
+    public name:string;
+    public message:string;
+    constructor(name:string = "", message:string = ""){
+        this.name = name;
+        this.message = message;
+    }
+}
+
+export class UrlException extends Exception{
+    constructor(){
+        super("UrlException","Invalid or empty url requested");
+        super.name;
+        super.message;
+    }
+}

--- a/src/app/core/services/http.service.ts
+++ b/src/app/core/services/http.service.ts
@@ -16,5 +16,13 @@ export class HttpService {
   public get<T>(url: string, activateHeader:boolean = false ):Observable<T> {
     return this.http.get<T>(url, activateHeader ? { headers: this._headers }: {});
   }
+
+  public post<T>(url: string, activateHeader:boolean = false, body:any ):Observable<T> {
+    return this.http.post<T>(url, body ,activateHeader ? { headers: this._headers }: {});
+  }
+
+  public put<T>(url: string, activateHeader:boolean = false,body:any ):Observable<T> {
+    return this.http.put<T>(url, body, activateHeader ? { headers: this._headers }: {});
+  }
 }
 

--- a/src/app/core/services/news-contacts.service.spec.ts
+++ b/src/app/core/services/news-contacts.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NewsContactsService } from './news-contacts.service';
+
+describe('NewsContactsService', () => {
+  let service: NewsContactsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NewsContactsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/news-contacts.service.ts
+++ b/src/app/core/services/news-contacts.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { HttpService } from "./http.service";
+import { UrlException } from "../lib/utils";
+
+@Injectable({
+  providedIn: "root",
+})
+export class NewsContactsService {
+  constructor(private _httpApiService_: HttpService) {}
+
+  public getContacts(
+    url: string = "",
+    headersNeeded: boolean = false
+  ): Observable<any> {
+
+    var request: any;
+    if (url) {
+      request = this._httpApiService_.get<any>(url, headersNeeded);
+      return request;
+    }else{
+      throw new UrlException();
+    }
+    
+  }
+
+  public createContacts(
+    url: string = "",
+    headersNeeded: boolean = false,
+    body: any = {}
+  ): Observable<any> {
+    if(url){
+      let request = this._httpApiService_.post<any>(url, headersNeeded, body);
+      return request;
+    } else {
+      throw new UrlException();
+    }
+  }
+
+  public editContact(
+    url: string = "",
+    headersNeeded: boolean = false,
+    body: any = {}
+  ): Observable<any> {
+    if(url) {
+      let request = this._httpApiService_.put<any>(url, headersNeeded, body);
+      return request;
+    } else {
+      throw new UrlException();
+    }
+  }
+}


### PR DESCRIPTION
Este es el servicio nuevo para manejar solo las peticiones http que tengan que ver con los componentes de contacto.
este servicio se conecta a otro servicio creado desde el commit inicial (HttpService)